### PR TITLE
OTP Burn Sequence Implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,10 @@ Arduino library for AS5048B from AMS
 	v1.0.1 - Typo to allow compiling on Codebender.cc (Math.h vs math.h) + Wind vane example modification to comply with the Timer.h lib used by them
 	v1.0.2 - ams_as5048b.cpp - fix setZeroReg() issue raised by @MechatronicsWorkman
 	v1.0.3 - Small bug fix and improvement by @DavidHowlett
+	v1.0.4 - Implemented OTP register burning by @brentyi
 
 AS5048B is a 14-bit magnetic rotary position sensor with digital angle (I2C) and PWM output.
-This library deals only with the I2C channel
+This library deals only with the I2C channel.
 
 
 [AS5048B's](http://www.ams.com/eng/Products/Position-Sensors/Magnetic-Rotary-Position-Sensors/AS5048B) AMS page.
@@ -21,22 +22,24 @@ This library deals only with the I2C channel
 - Computes an angular exponential moving average
 - Reads exponential moving average angle and outputting with various units
 - Resets Exp moving Avg
+- OTP setting
+- OTP programming sequence
 
 ## Code examples ##
 - Single angle reading, outputs 2 units
 - Angular exponential moving average reading, outputs read angle and average
 - Wind vane, outputs azimuth and compass direction - This one as a special #define for Codebender.cc support
 - Dial reading for X-Plane
+- Slave address programming
 
 ## Not available yet features ##
 - PWM reading
-- OTP setting
-- OTP programming sequence
 - Debug
 
 ## Testing ##
 - Tested against AS5048B's official [adapter board](http://www.ams.com/eng/Support/Demoboards/Position-Sensors/Rotary-Magnetic-Position-Sensors/AS5048B-Adapterboard)
 - Tested on Arduino Mega with Arduino IDE 1.0.5 && Codebender.cc
+- Tested on Arduino Uno with Arduino IDE 1.6.9
+- Tested on Arduino Nano with Arduino IDE 1.6.9
 - Tested on Teensy++ 2.0 with Arduino IDE 1.6.9
 - Please comment about other devices
-

--- a/ams_as5048b.cpp
+++ b/ams_as5048b.cpp
@@ -29,15 +29,13 @@
     Constructor
 */
 /**************************************************************************/
-AMS_AS5048B::AMS_AS5048B(void) 
-{
+AMS_AS5048B::AMS_AS5048B(void) {
 	_chipAddress = AS5048_ADDRESS;
 	_debugFlag = false;
 }
 
-AMS_AS5048B::AMS_AS5048B(uint8_t chipAddress) 
-{
-	_chipAddress = chipAddress;	
+AMS_AS5048B::AMS_AS5048B(uint8_t chipAddress) {
+	_chipAddress = chipAddress;
 	_debugFlag = false;
 }
 
@@ -48,10 +46,10 @@ AMS_AS5048B::AMS_AS5048B(uint8_t chipAddress)
 /**************************************************************************/
 /*!
     @brief  init values and overall behaviors for AS5948B use
-    
-    @params 
+
+    @params
 				none
-	@returns
+    @returns
 				none
 */
 /**************************************************************************/
@@ -67,29 +65,29 @@ void AMS_AS5048B::begin(void) {
 			Serial.begin(9600);
 		}
 	#endif
-	
+
 	_clockWise = false;
 	_lastAngleRaw = 0.0;
 	_zeroRegVal = AMS_AS5048B::zeroRegR();
 	_addressRegVal = AMS_AS5048B::addressRegR();
-	
+
 	AMS_AS5048B::resetMovingAvgExp();
-	
+
 	return;
 }
 
 /**************************************************************************/
 /*!
     @brief  Toggle debug output to serial
-    
-    @params 
+
+    @params
 				none
-	@returns
+    @returns
 				none
 */
 /**************************************************************************/
 void AMS_AS5048B::toggleDebug(void) {
-	
+
 	_debugFlag = !_debugFlag;
 	return;
 }
@@ -97,15 +95,15 @@ void AMS_AS5048B::toggleDebug(void) {
 /**************************************************************************/
 /*!
     @brief  Set / unset clock wise counting - sensor counts CCW natively
-    
-    @params[in] 
+
+    @params[in]
 				boolean cw - true: CW, false: CCW
-	@returns
+    @returns
 				none
 */
 /**************************************************************************/
 void AMS_AS5048B::setClockWise(boolean cw = true) {
-	
+
 	_clockWise = cw;
 	_lastAngleRaw = 0.0;
 	AMS_AS5048B::resetMovingAvgExp();
@@ -115,25 +113,25 @@ void AMS_AS5048B::setClockWise(boolean cw = true) {
 /**************************************************************************/
 /*!
     @brief  writes OTP register - not done
-    
-    @params[in] 
+
+    @params[in]
 				unit8_t register value
-	@returns
+    @returns
 				none
 */
 /**************************************************************************/
 void AMS_AS5048B::progRegister(uint8_t regVal) {
-	
+
 	return;
 }
 
 /**************************************************************************/
 /*!
     @brief  Starts prog sequence according to datasheet - not done
-    
-    @params[in] 
+
+    @params[in]
 				none
-	@returns
+    @returns
 				none
 */
 /**************************************************************************/
@@ -145,10 +143,10 @@ void AMS_AS5048B::doProg(void) {
 /**************************************************************************/
 /*!
     @brief  write I2C address value (5 bits) into the address register - not done
-    
-    @params[in] 
+
+    @params[in]
 				unit8_t register value
-	@returns
+    @returns
 				none
 */
 /**************************************************************************/
@@ -161,10 +159,10 @@ void AMS_AS5048B::addressRegW(uint8_t regVal) {
 /**************************************************************************/
 /*!
     @brief  reads I2C address register value
-    
-    @params[in] 
+
+    @params[in]
 				none
-	@returns
+    @returns
 				uint8_t register value
 */
 /**************************************************************************/
@@ -176,17 +174,17 @@ uint8_t AMS_AS5048B::addressRegR(void) {
 /**************************************************************************/
 /*!
     @brief  sets current angle as the zero position
-    
-    @params[in] 
+
+    @params[in]
 				none
-	@returns
+    @returns
 				none
 */
 /**************************************************************************/
 void AMS_AS5048B::setZeroReg(void) {
-	
+
 	uint16_t newZero = AMS_AS5048B::readReg16(AS5048B_ANGLMSB_REG);
-	AMS_AS5048B::zeroRegW((uint16_t) 0x00); //Issue closed by @MechatronicsWorkman 
+	AMS_AS5048B::zeroRegW((uint16_t) 0x00); //Issue closed by @MechatronicsWorkman
 	AMS_AS5048B::zeroRegW(newZero);
 	return;
 }
@@ -194,10 +192,10 @@ void AMS_AS5048B::setZeroReg(void) {
 /**************************************************************************/
 /*!
     @brief  writes the 2 bytes Zero position register value
-    
-    @params[in] 
+
+    @params[in]
 				unit16_t register value
-	@returns
+    @returns
 				none
 */
 /**************************************************************************/
@@ -211,10 +209,10 @@ void AMS_AS5048B::zeroRegW(uint16_t regVal) {
 /**************************************************************************/
 /*!
     @brief  reads the 2 bytes Zero position register value
-    
-    @params[in] 
+
+    @params[in]
 				none
-	@returns
+    @returns
 				uint16_t register value trimmed on 14 bits
 */
 /**************************************************************************/
@@ -226,10 +224,10 @@ uint16_t AMS_AS5048B::zeroRegR(void) {
 /**************************************************************************/
 /*!
     @brief  reads the 2 bytes magnitude register value
-    
-    @params[in] 
+
+    @params[in]
 				none
-	@returns
+    @returns
 				uint16_t register value trimmed on 14 bits
 */
 /**************************************************************************/
@@ -239,18 +237,18 @@ uint16_t AMS_AS5048B::magnitudeR(void) {
 }
 
 uint16_t AMS_AS5048B::angleRegR(void) {
-	
+
 	return AMS_AS5048B::readReg16(AS5048B_ANGLMSB_REG);
 }
 
 /**************************************************************************/
 /*!
     @brief  reads the 1 bytes auto gain register value
-    
-    @params[in] 
+
+    @params[in]
 				none
-	@returns
-				uint8_t register value 
+    @returns
+				uint8_t register value
 */
 /**************************************************************************/
 uint8_t AMS_AS5048B::getAutoGain(void) {
@@ -261,11 +259,11 @@ uint8_t AMS_AS5048B::getAutoGain(void) {
 /**************************************************************************/
 /*!
     @brief  reads the 1 bytes diagnostic register value
-    
-    @params[in] 
+
+    @params[in]
 				none
-	@returns
-				uint8_t register value 
+    @returns
+				uint8_t register value
 */
 /**************************************************************************/
 uint8_t AMS_AS5048B::getDiagReg(void) {
@@ -276,20 +274,19 @@ uint8_t AMS_AS5048B::getDiagReg(void) {
 /**************************************************************************/
 /*!
     @brief  reads current angle value and converts it into the desired unit
-    
-    @params[in] 
-				String unit : string expressing the unit of the angle. Sensor raw value as default	
-    @params[in] 
+
+    @params[in]
+				String unit : string expressing the unit of the angle. Sensor raw value as default
+    @params[in]
 				Boolean newVal : have a new measurement or use the last read one. True as default
-				
-	@returns
-				Double angle value converted into the desired unit 
+    @returns
+				Double angle value converted into the desired unit
 */
 /**************************************************************************/
 double AMS_AS5048B::angleR(int unit = U_RAW, boolean newVal = true) {
 
 	double angleRaw;
-	
+
 	if (newVal) {
 		if(_clockWise) {
 			angleRaw = (double) (0b11111111111111 - AMS_AS5048B::readReg16(AS5048B_ANGLMSB_REG));
@@ -308,14 +305,13 @@ double AMS_AS5048B::angleR(int unit = U_RAW, boolean newVal = true) {
 
 /**************************************************************************/
 /*!
-    @brief  Performs an exponential moving average on the angle. 
+    @brief  Performs an exponential moving average on the angle.
 			Works on Sine and Cosine of the angle to avoid issues 0°/360° discontinuity
-    
-    @params[in] 
-				none	
-				
-	@returns
-				none 
+
+    @params[in]
+				none
+    @returns
+				none
 */
 /**************************************************************************/
 void AMS_AS5048B::updateMovingAvgExp(void) {
@@ -323,7 +319,7 @@ void AMS_AS5048B::updateMovingAvgExp(void) {
 	//sine and cosine calculation on angles in radian
 
 	double angle = AMS_AS5048B::angleR(U_RAD, true);
-	
+
 	if (_movingAvgCountLoop < EXP_MOVAVG_LOOP) {
 		_movingAvgExpSin += sin(angle);
 		_movingAvgExpCos += cos(angle);
@@ -338,20 +334,19 @@ void AMS_AS5048B::updateMovingAvgExp(void) {
 		double movavgexpcos = _movingAvgExpCos + _movingAvgExpAlpha * (cos(angle) - _movingAvgExpCos);
 		_movingAvgExpSin = movavgexpsin;
 		_movingAvgExpCos = movavgexpcos;
-		_movingAvgExpAngle = getExpAvgRawAngle();	
+		_movingAvgExpAngle = getExpAvgRawAngle();
 	}
-	
+
 	return;
 }
 
 /**************************************************************************/
 /*!
     @brief  sent back the exponential moving averaged angle in the desired unit
-    
-    @params[in] 
-				String unit : string expressing the unit of the angle. Sensor raw value as default 	
-				
-	@returns
+
+    @params[in]
+				String unit : string expressing the unit of the angle. Sensor raw value as default
+    @returns
 				Double exponential moving averaged angle value
 */
 /**************************************************************************/
@@ -361,7 +356,7 @@ double AMS_AS5048B::getMovingAvgExp(int unit = U_RAW) {
 }
 
 void AMS_AS5048B::resetMovingAvgExp(void) {
-	
+
 	_movingAvgExpAngle = 0.0;
 	_movingAvgCountLoop = 0;
 	_movingAvgExpAlpha = 2.0 / (EXP_MOVAVG_N + 1.0);
@@ -374,11 +369,11 @@ void AMS_AS5048B::resetMovingAvgExp(void) {
 /*========================================================================*/
 
 uint8_t AMS_AS5048B::readReg8(uint8_t address) {
-	
+
 	uint8_t readValue;
 	byte requestResult;
 	uint8_t nbByte2Read = 1;
-	
+
 	Wire.beginTransmission(_chipAddress);
 	Wire.write(address);
 	requestResult = Wire.endTransmission(false);
@@ -389,32 +384,32 @@ uint8_t AMS_AS5048B::readReg8(uint8_t address) {
 
 	Wire.requestFrom(_chipAddress, nbByte2Read);
 	readValue = (uint8_t) Wire.read();
-	
+
 	return readValue;
 }
 
 uint16_t AMS_AS5048B::readReg16(uint8_t address) {
 	//16 bit value got from 2 8bits registers (7..0 MSB + 5..0 LSB) => 14 bits value
-	
+
 	uint8_t nbByte2Read = 2;
 	byte requestResult;
 	byte readArray[2];
 	uint16_t readValue = 0;
-	
+
 	Wire.beginTransmission(_chipAddress);
 	Wire.write(address);
 	requestResult = Wire.endTransmission(false);
-    if (requestResult){
-        Serial.print("I2C error: ");
-        Serial.println(requestResult);
-    }
+	if (requestResult){
+		Serial.print("I2C error: ");
+		Serial.println(requestResult);
+	}
 
-	
+
 	Wire.requestFrom(_chipAddress, nbByte2Read);
 	for (byte i=0; i < nbByte2Read; i++) {
 		readArray[i] = Wire.read();
 	}
-	
+
 	readValue = (((uint16_t) readArray[0]) << 6);
 	readValue += (readArray[1] & 0x3F);
 	/*
@@ -436,11 +431,11 @@ void AMS_AS5048B::writeReg(uint8_t address, uint8_t value) {
 }
 
 double AMS_AS5048B::convertAngle(int unit, double angle) {
-	
+
 	// convert raw sensor reading into angle unit
-	
+
 	double angleConv;
-	
+
 	switch (unit) {
 		case U_RAW:
 			//Sensor raw measurement
@@ -485,22 +480,23 @@ double AMS_AS5048B::convertAngle(int unit, double angle) {
 		default:
 			//no conversion => raw angle
 			angleConv = angle;
-			break;	
-	}	
+			break;
+	}
 	return angleConv;
 }
 
 double AMS_AS5048B::getExpAvgRawAngle(void) {
+
 	double angle;
 	double twopi = 2 * M_PI;
-	
+
 	if (_movingAvgExpSin < 0.0) {
 		angle = twopi - acos(_movingAvgExpCos);
 	}
 	else {
 		angle = acos(_movingAvgExpCos);
 	}
-	
+
 	angle = (angle / twopi) * AS5048B_RESOLUTION;
 
 	return angle;

--- a/ams_as5048b.cpp
+++ b/ams_as5048b.cpp
@@ -140,12 +140,15 @@ void AMS_AS5048B::doProg(void) {
 
 	//enable special programming mode
 	AMS_AS5048B::progRegister(0xFD);
+	delay(10);
 
 	//set the burn bit: enables automatic programming procedure
 	AMS_AS5048B::progRegister(0x08);
+	delay(10);
 
 	//disable special programming mode
 	AMS_AS5048B::progRegister(0x00);
+	delay(10);
 
 	return;
 }

--- a/ams_as5048b.h
+++ b/ams_as5048b.h
@@ -1,8 +1,8 @@
 /**************************************************************************/
-/*! 
+/*!
     @file     ams_as5048b.h
     @author   SOSAndroid.fr (E. Ha.)
-	
+
     @section  HISTORY
 
     v1.0 - First release
@@ -10,7 +10,7 @@
 	v1.0.2 - Small bug fix and improvement by @DavidHowlett
 
     Library to interface the AS5048B magnetic rotary encoder from AMS over the I2C bus
-	
+
     @section LICENSE
 
     Software License Agreement (BSD License)
@@ -101,13 +101,13 @@ class AMS_AS5048B {
  public:
 	AMS_AS5048B(void);
 	AMS_AS5048B(uint8_t chipAddress);
-	
+
 	void		begin(void); // to init the object, must be called in the setup loop
 	void		toggleDebug(void); // start / stop debug through serial at anytime
 	void		setClockWise(boolean cw); //set clockwise counting, default is false (native sensor)
 	void		progRegister(uint8_t regVal); //nothing so far - manipulate the OTP register
-	void		doProg(void); //progress programming OTP (not implemented)
-	void		addressRegW(uint8_t regVal); //change the chip address (not implemented)
+	void		doProg(void); //progress programming OTP
+	void		addressRegW(uint8_t regVal); //change the chip address
 	uint8_t		addressRegR(void); //read chip address
 	void		setZeroReg(void); //set Zero to current angle position
 	void		zeroRegW(uint16_t regVal); //write Zero register value
@@ -115,14 +115,14 @@ class AMS_AS5048B {
 	uint16_t	angleRegR(void); //read raw value of the angle register
 	uint8_t		diagR(void); //read diagnostic register
 	uint16_t	magnitudeR(void); //read current magnitude
-	double		angleR(int unit, boolean newVal); //Read current angle or get last measure with unit conversion : RAW, TRN, DEG, RAD, GRAD, MOA, SOA, MILNATO, MILSE, MILRU	
+	double		angleR(int unit, boolean newVal); //Read current angle or get last measure with unit conversion : RAW, TRN, DEG, RAD, GRAD, MOA, SOA, MILNATO, MILSE, MILRU
 	uint8_t		getAutoGain(void);
 	uint8_t		getDiagReg(void);
 
 	void		updateMovingAvgExp(void); //measure the current angle and feed the Exponential Moving Average calculation
 	double		getMovingAvgExp(int unit); //get Exponential Moving Average calculation
 	void		resetMovingAvgExp(void); //reset Exponential Moving Average calculation values
-  
+
  private:
 	//variables
 	boolean		_debugFlag;
@@ -135,8 +135,8 @@ class AMS_AS5048B {
 	double		_movingAvgExpSin;
 	double		_movingAvgExpCos;
 	double		_movingAvgExpAlpha;
-	int			_movingAvgCountLoop;
-	
+	int		_movingAvgCountLoop;
+
 	//methods
 	uint8_t		readReg8(uint8_t address);
 	uint16_t	readReg16(uint8_t address); //16 bit value got from 2x8bits registers (7..0 MSB + 5..0 LSB) => 14 bits value

--- a/examples/angle_moving_avg/angle_moving_avg.ino
+++ b/examples/angle_moving_avg/angle_moving_avg.ino
@@ -4,8 +4,8 @@
     @author   SOSAndroid (E. Ha.)
     @license  BSD (see license.txt)
 
-	read over I2C bus and averaging angle 
-	
+	read over I2C bus and averaging angle
+
     @section  HISTORY
 
     v1.0 - First release
@@ -35,36 +35,34 @@ void setup() {
 	//Start serial
 	Serial.begin(9600);
 	while (!Serial) ; //wait until Serial ready
-	
+
 	//Start Wire object. Unneeded here as this is done (optionnaly) by AMS_AS5048B object (see lib code - #define USE_WIREBEGIN_ENABLED)
 	//Wire.begin();
 
 	//init AMS_AS5048B object
 	mysensor.begin();
-	
-    //set clock wise counting
-    mysensor.setClockWise(true); 
-    
-    //set the 0 to the sensorr
-    //mysensor.zeroRegW(0x0);
-    
+
+	//set clock wise counting
+	mysensor.setClockWise(true); 
+
+	//set the 0 to the sensorr
+	//mysensor.zeroRegW(0x0);
+
 }
 
 void loop() {
-	
-    //prints to serial the read angle in degree and its average every 2 seconds
-	//prints 2 times the exact same angle - only one measurement
-    mysensor.updateMovingAvgExp();
 
-	
+	//prints to serial the read angle in degree and its average every 2 seconds
+	//prints 2 times the exact same angle - only one measurement
+	mysensor.updateMovingAvgExp();
+
+
 	Serial.print("Angle degree : ");
 	Serial.println(mysensor.angleR(U_DEG, false), DEC);
 
-    Serial.print("Average ");
-    Serial.println(mysensor.getMovingAvgExp(U_DEG), DEC);
+	Serial.print("Average ");
+	Serial.println(mysensor.getMovingAvgExp(U_DEG), DEC);
 
-        
-	
 	delay(2000);
 
 }

--- a/examples/program_address/program_address.ino
+++ b/examples/program_address/program_address.ino
@@ -4,12 +4,12 @@
     @author   brentyi
     @license  BSD (see license.txt)
 
-	Example code for programming the i2c slave address
-	Be careful -- this can only be once once!
+	Example sketch for programming the i2c slave address
+	Be careful -- this can only be done once!
 
     @section  HISTORY
 
-    v1.0 - First release
+    v1.0.4 - Added address programming example
 */
 /**************************************************************************/
 

--- a/examples/program_address/program_address.ino
+++ b/examples/program_address/program_address.ino
@@ -1,0 +1,57 @@
+/**************************************************************************/
+/*!
+    @file     program_address.ino
+    @author   brentyi
+    @license  BSD (see license.txt)
+
+	Example code for programming the i2c slave address
+	Be careful -- this can only be once once!
+
+    @section  HISTORY
+
+    v1.0 - First release
+*/
+/**************************************************************************/
+
+#include <ams_as5048b.h>
+
+//unit consts
+#define U_RAW 1
+#define U_TRN 2
+#define U_DEG 3
+#define U_RAD 4
+#define U_GRAD 5
+#define U_MOA 6
+#define U_SOA 7
+#define U_MILNATO 8
+#define U_MILSE 9
+#define U_MILRU 10
+
+// Construct our AS5048B object with an I2C address of 0x40
+AMS_AS5048B mysensor(0x40);
+
+void setup() {
+
+	//start serial
+	Serial.begin(9600);
+	while (!Serial) ; //wait until Serial ready
+
+	// Initialize our sensor
+	mysensor.begin();
+
+	// Set the first five MSBs, where the MSB will be internally inverted
+	// If A1 & A2 are pulled low, our new address should be 0b1000100
+	mysensor.addressRegW(0x01);
+
+	// Burn our new address to the OTP register
+	mysensor.doProg();
+}
+
+void loop() {
+
+	// Print out angle readings -- this should work if programming succeeded
+	Serial.print("Angle degree : ");
+	Serial.println(mysensor.angleR(U_DEG, true), DEC);
+
+	delay(200);
+}

--- a/examples/read_simple_angle/read_simple_angle.ino
+++ b/examples/read_simple_angle/read_simple_angle.ino
@@ -5,7 +5,7 @@
     @license  BSD (see license.txt)
 
 	read a simple angle from AS5048B over I2C bus
-	
+
     @section  HISTORY
 
     v1.0 - First release
@@ -33,13 +33,13 @@ void setup() {
 	//Start serial
 	Serial.begin(9600);
 	while (!Serial) ; //wait until Serial ready
-	
-	//Start Wire object. Unneeded here as this is done (optionnaly) by AMS_AS5048B object (see lib code - #define USE_WIREBEGIN_ENABLED)
+
+	//Start Wire object. Unneeded here as this is done (optionally) by the AMS_AS5048B object (see lib code - #define USE_WIREBEGIN_ENABLED)
 	//Wire.begin();
 
 	//init AMS_AS5048B object
 	mysensor.begin();
-	
+
 	//consider the current position as zero
 	mysensor.setZeroReg();
 
@@ -50,9 +50,9 @@ void loop() {
 	//print 2 times the exact same angle - only one measurement
 	Serial.print("Angle sensor raw : ");
 	Serial.println(mysensor.angleR(U_RAW, true), DEC);
-	
+
 	Serial.print("Angle degree : ");
 	Serial.println(mysensor.angleR(U_DEG, false), DEC);
-	
+
 	delay(2000);
 }

--- a/examples/xplane_dials/xplane_dials.ino
+++ b/examples/xplane_dials/xplane_dials.ino
@@ -13,7 +13,7 @@
         - Set the board type to Teensy++ 2.0 (or which ever version of Teensy you are using)
         - Set the USB type to "Flight Sim Controls" in the tools menu (this adds some definitions)
         - Uncomment the marked lines
-    
+
 
     @section  HISTORY
 
@@ -32,7 +32,7 @@
 AMS_AS5048B sensors[NUM_SENSORS] = {AMS_AS5048B(0x40), AMS_AS5048B(0x41), AMS_AS5048B(0x42), AMS_AS5048B(0x43)};
 
 // the below line can be uncommented if you install Teensyduino
-//FlightSimFloat angles[NUM_SENSORS]; 
+//FlightSimFloat angles[NUM_SENSORS];
 
 void setup() {
     //Start serial


### PR DESCRIPTION
Implemented the programming sequence and added a relevant example, as per AMS's application note on slave address programming for the 5048B:
![](http://i.imgur.com/Ll32NvM.png)

This also works for burning the zero position, and is pretty much the same as their recommended procedure for doing so. It's just missing the verification step, which can be easily done by the user or implemented as a separate function.

I also took the liberty of updating the README and cleaning up some whitespace inconsistencies -- let me know if there are any issues with any of my changes!