### PR TITLE
Default arguments fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Arduino library for AS5048B from AMS
 	v1.0.2 - ams_as5048b.cpp - fix setZeroReg() issue raised by @MechatronicsWorkman
 	v1.0.3 - Small bug fix and improvement by @DavidHowlett
 	v1.0.4 - Implemented OTP register burning by @brentyi
+	v1.0.5 - Optional parameters fix
 
 AS5048B is a 14-bit magnetic rotary position sensor with digital angle (I2C) and PWM output.
 This library deals only with the I2C channel.

--- a/ams_as5048b.cpp
+++ b/ams_as5048b.cpp
@@ -102,7 +102,7 @@ void AMS_AS5048B::toggleDebug(void) {
 				none
 */
 /**************************************************************************/
-void AMS_AS5048B::setClockWise(boolean cw = true) {
+void AMS_AS5048B::setClockWise(boolean cw) {
 
 	_clockWise = cw;
 	_lastAngleRaw = 0.0;
@@ -301,7 +301,7 @@ uint8_t AMS_AS5048B::getDiagReg(void) {
 				Double angle value converted into the desired unit
 */
 /**************************************************************************/
-double AMS_AS5048B::angleR(int unit = U_RAW, boolean newVal = true) {
+double AMS_AS5048B::angleR(int unit, boolean newVal) {
 
 	double angleRaw;
 
@@ -368,7 +368,7 @@ void AMS_AS5048B::updateMovingAvgExp(void) {
 				Double exponential moving averaged angle value
 */
 /**************************************************************************/
-double AMS_AS5048B::getMovingAvgExp(int unit = U_RAW) {
+double AMS_AS5048B::getMovingAvgExp(int unit) {
 
 	return AMS_AS5048B::convertAngle(unit, _movingAvgExpAngle);
 }

--- a/ams_as5048b.h
+++ b/ams_as5048b.h
@@ -104,7 +104,7 @@ class AMS_AS5048B {
 
 	void		begin(void); // to init the object, must be called in the setup loop
 	void		toggleDebug(void); // start / stop debug through serial at anytime
-	void		setClockWise(boolean cw); //set clockwise counting, default is false (native sensor)
+	void		setClockWise(boolean cw = true); //set clockwise counting, default is false (native sensor)
 	void		progRegister(uint8_t regVal); //nothing so far - manipulate the OTP register
 	void		doProg(void); //progress programming OTP
 	void		addressRegW(uint8_t regVal); //change the chip address
@@ -115,12 +115,12 @@ class AMS_AS5048B {
 	uint16_t	angleRegR(void); //read raw value of the angle register
 	uint8_t		diagR(void); //read diagnostic register
 	uint16_t	magnitudeR(void); //read current magnitude
-	double		angleR(int unit, boolean newVal); //Read current angle or get last measure with unit conversion : RAW, TRN, DEG, RAD, GRAD, MOA, SOA, MILNATO, MILSE, MILRU
+	double		angleR(int unit = U_RAW, boolean newVal = true); //Read current angle or get last measure with unit conversion : RAW, TRN, DEG, RAD, GRAD, MOA, SOA, MILNATO, MILSE, MILRU
 	uint8_t		getAutoGain(void);
 	uint8_t		getDiagReg(void);
 
 	void		updateMovingAvgExp(void); //measure the current angle and feed the Exponential Moving Average calculation
-	double		getMovingAvgExp(int unit); //get Exponential Moving Average calculation
+	double		getMovingAvgExp(int unit = U_RAW); //get Exponential Moving Average calculation
 	void		resetMovingAvgExp(void); //reset Exponential Moving Average calculation values
 
  private:


### PR DESCRIPTION
Hey!

Omitting optional parameters currently results in a compiler error -- this PR fixes that.

I moved all of the default argument definitions from their respective function implementations to their prototypes, which makes them visible to avr-gcc during sketch compilation.