### PR TITLE
New method to burn zero position OTP register

### DIFF
--- a/ams_as5048b.cpp
+++ b/ams_as5048b.cpp
@@ -178,7 +178,7 @@ void AMS_AS5048B::doProgZero(void) {
 	delay(10);
 
 	//enable verification
-	AMS_AS5048B::progRegister(0x00);
+	AMS_AS5048B::progRegister(0x40);
 	delay(10);
 
 	//read angle information (equals to 0)

--- a/ams_as5048b.cpp
+++ b/ams_as5048b.cpp
@@ -128,7 +128,7 @@ void AMS_AS5048B::progRegister(uint8_t regVal) {
 
 /**************************************************************************/
 /*!
-    @brief  Burn values to the OTP register
+    @brief  Burn values to the slave address OTP register
 
     @params[in]
 				none
@@ -148,6 +148,41 @@ void AMS_AS5048B::doProg(void) {
 
 	//disable special programming mode
 	AMS_AS5048B::progRegister(0x00);
+	delay(10);
+
+	return;
+}
+
+/**************************************************************************/
+/*!
+    @brief  Burn values to the zero position OTP register
+
+    @params[in]
+				none
+    @returns
+				none
+*/
+/**************************************************************************/
+void AMS_AS5048B::doProg(void) {
+	//this will burn the zero position OTP register like described in the datasheet
+	//enable programming mode
+	AMS_AS5048B::progRegister(0x01);
+	delay(10);
+
+	//set the burn bit: enables automatic programming procedure
+	AMS_AS5048B::progRegister(0x08);
+	delay(10);
+
+	//read angle information (equals to 0)
+	AMS_AS5048B::readReg16(AS5048B_ANGLMSB_REG);
+	delay(10);
+
+	//enable verification
+	AMS_AS5048B::progRegister(0x00);
+	delay(10);
+
+	//read angle information (equals to 0)
+	AMS_AS5048B::readReg16(AS5048B_ANGLMSB_REG);
 	delay(10);
 
 	return;

--- a/ams_as5048b.cpp
+++ b/ams_as5048b.cpp
@@ -163,7 +163,7 @@ void AMS_AS5048B::doProg(void) {
 				none
 */
 /**************************************************************************/
-void AMS_AS5048B::doProg(void) {
+void AMS_AS5048B::doProgZero(void) {
 	//this will burn the zero position OTP register like described in the datasheet
 	//enable programming mode
 	AMS_AS5048B::progRegister(0x01);

--- a/ams_as5048b.h
+++ b/ams_as5048b.h
@@ -106,7 +106,8 @@ class AMS_AS5048B {
 	void		toggleDebug(void); // start / stop debug through serial at anytime
 	void		setClockWise(boolean cw = true); //set clockwise counting, default is false (native sensor)
 	void		progRegister(uint8_t regVal); //nothing so far - manipulate the OTP register
-	void		doProg(void); //progress programming OTP
+	void		doProg(void); //progress programming slave address OTP
+	void		doProgZero(void); //progress programming zero position OTP
 	void		addressRegW(uint8_t regVal); //change the chip address
 	uint8_t		addressRegR(void); //read chip address
 	void		setZeroReg(void); //set Zero to current angle position


### PR DESCRIPTION
added a method to burn the zero position to OTP register
See issue #6